### PR TITLE
Add Cinematic Drop Ship Sequence for Battle Royale

### DIFF
--- a/Cinematics/TitanPCDropShipSequence.cpp
+++ b/Cinematics/TitanPCDropShipSequence.cpp
@@ -1,0 +1,234 @@
+#include "TitanPCDropShipSequence.h"
+#include "Camera/CameraComponent.h"
+#include "Components/StaticMeshComponent.h"
+#include "Kismet/GameplayStatics.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Pawn.h"
+#include "TitanPCCharacter.h"
+
+ATitanPCDropShipSequence::ATitanPCDropShipSequence()
+{
+    PrimaryActorTick.bCanEverTick = true;
+    SetActorEnableCollision(false);
+    bReplicates = false; // Local cinematic
+
+    PlaneMeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("PlaneMesh"));
+    PlaneMeshComponent->SetupAttachment(RootComponent);
+    PlaneMeshComponent->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+    PlaneMeshComponent->SetVisibility(false); // Hidden until asset assigned
+
+    SequenceCamera = CreateDefaultSubobject<UCameraComponent>(TEXT("SequenceCamera"));
+    SequenceCamera->SetupAttachment(PlaneMeshComponent);
+    SequenceCamera->bUsePawnControlRotation = false;
+    SequenceCamera->SetFieldOfView(90.0f);
+}
+
+void ATitanPCDropShipSequence::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (PlaneStaticMeshAsset)
+    {
+        PlaneMeshComponent->SetStaticMesh(PlaneStaticMeshAsset);
+        PlaneMeshComponent->SetVisibility(true);
+    }
+
+    // Build a default path if none was provided
+    if (Waypoints.Num() == 0)
+    {
+        BuildDefaultPath();
+    }
+
+    // Initialize starting location
+    if (Waypoints.Num() > 0)
+    {
+        CurrentLocation = Waypoints[0] + FVector(0, 0, Altitude);
+        SetActorLocation(CurrentLocation);
+    }
+}
+
+void ATitanPCDropShipSequence::Tick(float DeltaSeconds)
+{
+    Super::Tick(DeltaSeconds);
+
+    if (!bSequenceActive)
+    {
+        return;
+    }
+
+    if (!bDroppingPlayer)
+    {
+        AdvanceAlongPath(DeltaSeconds);
+
+        // If we've reached final waypoint, hold briefly then eject
+        if (CurrentWaypointIndex >= Waypoints.Num())
+        {
+            EndHoldTimer += DeltaSeconds;
+            if (EndHoldTimer >= HoldAtEndTime)
+            {
+                EjectPlayer();
+            }
+        }
+    }
+    else
+    {
+        // Simulate fast drop: move character from sky to ground smoothly, then finish
+        if (bSimulateFastDrop && TargetCharacter)
+        {
+            FVector NewLoc = TargetCharacter->GetActorLocation();
+            FVector Direction = (DropTargetLocation - NewLoc).GetSafeNormal();
+            float Dist = FVector::Dist(NewLoc, DropTargetLocation);
+            float Step = DropSpeed * DeltaSeconds;
+
+            if (Dist <= Step)
+            {
+                TargetCharacter->SetActorLocation(DropTargetLocation);
+                bDroppingPlayer = false;
+                OnSequenceFinished.Broadcast();
+
+                // Return view to character and enable input
+                if (OwningController && TargetCharacter)
+                {
+                    OwningController->SetViewTarget(TargetCharacter);
+                    OwningController->Possess(TargetCharacter);
+                    OwningController->bShowMouseCursor = false;
+                    FInputModeGameOnly InputMode;
+                    OwningController->SetInputMode(InputMode);
+                }
+
+                // Destroy sequence actor
+                Destroy();
+            }
+            else
+            {
+                TargetCharacter->SetActorLocation(NewLoc + Direction * Step);
+            }
+        }
+    }
+
+    UpdateCameraTransform();
+}
+
+void ATitanPCDropShipSequence::StartSequence(APlayerController* InController, ATitanPCCharacter* InCharacter)
+{
+    OwningController = InController;
+    TargetCharacter = InCharacter;
+
+    if (!OwningController || !TargetCharacter || Waypoints.Num() == 0)
+    {
+        // Fail-safe: do nothing if missing critical info
+        return;
+    }
+
+    bSequenceActive = true;
+    CurrentWaypointIndex = 1; // Start moving toward waypoint 1 from 0
+
+    // Put player into cinematic view and temporarily unpossess character
+    OwningController->SetViewTarget(this);
+    OwningController->UnPossess();
+    OwningController->bShowMouseCursor = false;
+    FInputModeGameOnly InputMode;
+    OwningController->SetInputMode(InputMode);
+
+    // Place character high above first waypoint so the drop feels coherent
+    DropStartLocation = Waypoints[0] + FVector(0, 0, Altitude + 1000.0f);
+    TargetCharacter->SetActorLocation(DropStartLocation);
+    TargetCharacter->DisableInput(OwningController);
+}
+
+void ATitanPCDropShipSequence::AdvanceAlongPath(float DeltaSeconds)
+{
+    if (Waypoints.Num() == 0 || CurrentWaypointIndex >= Waypoints.Num())
+    {
+        return;
+    }
+
+    const FVector Target = Waypoints[CurrentWaypointIndex] + FVector(0, 0, Altitude);
+    FVector Direction = (Target - CurrentLocation).GetSafeNormal();
+    float Distance = FVector::Dist(CurrentLocation, Target);
+    float Step = FlySpeed * DeltaSeconds;
+
+    if (Distance <= Step)
+    {
+        CurrentLocation = Target;
+        SetActorLocation(CurrentLocation);
+        CurrentWaypointIndex++;
+    }
+    else
+    {
+        CurrentLocation += Direction * Step;
+        SetActorLocation(CurrentLocation);
+        SetActorRotation(Direction.Rotation());
+    }
+}
+
+void ATitanPCDropShipSequence::EjectPlayer()
+{
+    bDroppingPlayer = true;
+
+    // Trace down to find ground location near the final waypoint
+    FVector Start = CurrentLocation;
+    FVector End = Start - FVector(0, 0, 100000.0f);
+
+    FHitResult Hit;
+    FCollisionQueryParams Params;
+    Params.bTraceComplex = false;
+    Params.AddIgnoredActor(this);
+    if (TargetCharacter)
+    {
+        Params.AddIgnoredActor(TargetCharacter);
+    }
+
+    if (GetWorld()->LineTraceSingleByChannel(Hit, Start, End, ECC_WorldStatic, Params))
+    {
+        DropTargetLocation = Hit.Location + FVector(0, 0, 100.0f); // small offset above ground
+    }
+    else
+    {
+        // Fallback: just drop near last waypoint at low altitude
+        DropTargetLocation = Waypoints.Last() + FVector(0, 0, 200.0f);
+    }
+
+    // Enable input again during drop so player can look around (optional)
+    if (OwningController && TargetCharacter)
+    {
+        TargetCharacter->EnableInput(OwningController);
+    }
+}
+
+void ATitanPCDropShipSequence::UpdateCameraTransform()
+{
+    // Slight nose-down tilt for cinematic feel
+    FRotator CamRot = GetActorRotation();
+    CamRot.Pitch = CamRot.Pitch - 5.0f;
+    SequenceCamera->SetWorldLocation(GetActorLocation() + GetActorForwardVector() * 200.0f + FVector(0, 0, 100.0f));
+    SequenceCamera->SetWorldRotation(CamRot);
+}
+
+void ATitanPCDropShipSequence::BuildDefaultPath()
+{
+    // Build a simple two-point path across the map centered around player start
+    FVector Center = FVector::ZeroVector;
+
+    // Try to find PlayerStart actor
+    TArray<AActor*> FoundStarts;
+    UGameplayStatics::GetAllActorsWithTag(GetWorld(), FName(TEXT("PlayerStart")), FoundStarts);
+    if (FoundStarts.Num() > 0)
+    {
+        Center = FoundStarts[0]->GetActorLocation();
+    }
+    else
+    {
+        // Fallback: center of current level bounds via world origin
+        Center = FVector::ZeroVector;
+    }
+
+    // Create a left-to-right flight path
+    const float PathHalfLength = 50000.0f;
+    FVector Left = Center + FVector(0, -PathHalfLength, 0);
+    FVector Right = Center + FVector(0, PathHalfLength, 0);
+
+    Waypoints.Add(Left);
+    Waypoints.Add(Right);
+}

--- a/Cinematics/TitanPCDropShipSequence.h
+++ b/Cinematics/TitanPCDropShipSequence.h
@@ -1,0 +1,95 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "TitanPCDropShipSequence.generated.h"
+
+class UCameraComponent;
+class UStaticMeshComponent;
+class ATitanPCCharacter;
+
+/**
+ * Simple cinematic drop-ship sequence that flies over the map like a battle royale plane,
+ * then ejects the player and hands control back.
+ *
+ * This is asset-light (no meshes required) and focuses on camera + movement so you can run it immediately.
+ * You can later swap in a plane mesh and Niagara trails via Blueprint or defaults.
+ */
+UCLASS()
+class TITANPC_API ATitanPCDropShipSequence : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    ATitanPCDropShipSequence();
+
+    virtual void BeginPlay() override;
+    virtual void Tick(float DeltaSeconds) override;
+
+    // Entry point to start the sequence. Pass owning controller and the pawn to re-possess at the end.
+    UFUNCTION(BlueprintCallable, Category="DropShip")
+    void StartSequence(class APlayerController* InController, ATitanPCCharacter* InCharacter);
+
+    // Waypoints for flight path (world positions). If empty, a default straight path will be generated.
+    UPROPERTY(EditAnywhere, Category="DropShip|Path")
+    TArray<FVector> Waypoints;
+
+    // Speed of the plane along the path
+    UPROPERTY(EditAnywhere, Category="DropShip|Path")
+    float FlySpeed = 2000.0f;
+
+    // Height offset applied to waypoints to ensure the plane flies high
+    UPROPERTY(EditAnywhere, Category="DropShip|Path")
+    float Altitude = 3000.0f;
+
+    // Time the sequence waits at final waypoint before eject
+    UPROPERTY(EditAnywhere, Category="DropShip|Sequence")
+    float HoldAtEndTime = 1.5f;
+
+    // If true, will smoothly move the character from sky to ground after eject to simulate a quick drop
+    UPROPERTY(EditAnywhere, Category="DropShip|Sequence")
+    bool bSimulateFastDrop = true;
+
+    // Drop speed when simulating fast drop
+    UPROPERTY(EditAnywhere, Category="DropShip|Sequence")
+    float DropSpeed = 2500.0f;
+
+    // Optional: attach a simple static mesh to visualize the plane (you can set this in editor)
+    UPROPERTY(EditAnywhere, Category="DropShip|Visual")
+    UStaticMesh* PlaneStaticMeshAsset;
+
+    // Camera used for the cinematic. PlayerController will view through this until sequence ends.
+    UPROPERTY(VisibleAnywhere, Category="DropShip|Visual")
+    UCameraComponent* SequenceCamera;
+
+    // Fired when the sequence finishes and the player is re-possessed
+    UPROPERTY(BlueprintAssignable, Category="DropShip|Events")
+    FSimpleMulticastDelegate OnSequenceFinished;
+
+protected:
+    void AdvanceAlongPath(float DeltaSeconds);
+    void EjectPlayer();
+    void UpdateCameraTransform();
+
+    // Generates a simple default path if none provided: left-to-right across the current map bounds.
+    void BuildDefaultPath();
+
+private:
+    UPROPERTY()
+    APlayerController* OwningController;
+
+    UPROPERTY()
+    ATitanPCCharacter* TargetCharacter;
+
+    UPROPERTY()
+    UStaticMeshComponent* PlaneMeshComponent;
+
+    int32 CurrentWaypointIndex = 0;
+    FVector CurrentLocation = FVector::ZeroVector;
+    bool bSequenceActive = false;
+    bool bDroppingPlayer = false;
+    float EndHoldTimer = 0.0f;
+
+    // For drop sim
+    FVector DropStartLocation = FVector::ZeroVector;
+    FVector DropTargetLocation = FVector::ZeroVector;
+};

--- a/TitanPCGameModeBase.cpp
+++ b/TitanPCGameModeBase.cpp
@@ -10,6 +10,8 @@ ATitanPCGameModeBase::ATitanPCGameModeBase()
 {
     DefaultPawnClass = ATitanPCCharacter::StaticClass();
     PlayerControllerClass = ATitanPCPlayerController::StaticClass();
+    // Set default cinematic class so it runs without extra setup
+    DropShipSequenceClass = ATitanPCDropShipSequence::StaticClass();
 }
 
 void ATitanPCGameModeBase::BeginPlay()

--- a/TitanPCGameModeBase.cpp
+++ b/TitanPCGameModeBase.cpp
@@ -2,9 +2,41 @@
 #include "TitanPCGameModeBase.h"
 #include "TitanPCCharacter.h"
 #include "TitanPCPlayerController.h"
+#include "Engine/World.h"
+#include "Kismet/GameplayStatics.h"
+#include "Cinematics/TitanPCDropShipSequence.h"
 
 ATitanPCGameModeBase::ATitanPCGameModeBase()
 {
     DefaultPawnClass = ATitanPCCharacter::StaticClass();
     PlayerControllerClass = ATitanPCPlayerController::StaticClass();
+}
+
+void ATitanPCGameModeBase::BeginPlay()
+{
+    Super::BeginPlay();
+    StartBattleRoyaleIntro();
+}
+
+void ATitanPCGameModeBase::StartBattleRoyaleIntro()
+{
+    if (!DropShipSequenceClass)
+    {
+        // You can assign DropShipSequenceClass in the GameMode BP or DefaultGame.ini.
+        return;
+    }
+
+    UWorld* World = GetWorld();
+    if (!World) return;
+
+    APlayerController* PC = UGameplayStatics::GetPlayerController(World, 0);
+    ATitanPCCharacter* Character = Cast<ATitanPCCharacter>(UGameplayStatics::GetPlayerPawn(World, 0));
+    if (!PC || !Character) return;
+
+    FActorSpawnParameters Params;
+    Params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+    ActiveDropSequence = World->SpawnActor<ATitanPCDropShipSequence>(DropShipSequenceClass, FVector::ZeroVector, FRotator::ZeroRotator, Params);
+    if (!ActiveDropSequence) return;
+
+    ActiveDropSequence->StartSequence(PC, Character);
 }

--- a/TitanPCGameModeBase.h
+++ b/TitanPCGameModeBase.h
@@ -3,6 +3,10 @@
 #include "GameFramework/GameModeBase.h"
 #include "TitanPCGameModeBase.generated.h"
 
+class ATitanPCDropShipSequence;
+class ATitanPCCharacter;
+class APlayerController;
+
 UCLASS()
 class TITANPC_API ATitanPCGameModeBase : public AGameModeBase
 {
@@ -10,4 +14,16 @@ class TITANPC_API ATitanPCGameModeBase : public AGameModeBase
 
 public:
     ATitanPCGameModeBase();
+
+protected:
+    virtual void BeginPlay() override;
+
+    // Optional: set to your custom cinematic class in defaults or via BP
+    UPROPERTY(EditDefaultsOnly, Category="Cinematic")
+    TSubclassOf<ATitanPCDropShipSequence> DropShipSequenceClass;
+
+    UPROPERTY()
+    ATitanPCDropShipSequence* ActiveDropSequence = nullptr;
+
+    void StartBattleRoyaleIntro();
 };


### PR DESCRIPTION
This pull request introduces a new cinematic drop ship sequence in the game, enhancing the gameplay experience to replicate a battle royale-style aircraft drop. The sequence is implemented within the `TitanPCDropShipSequence` class, allowing for dynamic movement over a defined path and ejecting the player character smoothly as they land. The animation is designed to be asset-light and provides an engaging entry into gameplay by focusing on camera movement and character control.

Changes include:
- New files for the drop ship sequence including functionality for player ejection and cinematic camera control.
- Modifications to the game mode to integrate the drop ship sequence at the start of the game.
- Configuration options for flight speed, altitude, and drop speed to tailor the experience.

---

> This pull request was co-created with Cosine Genie

Original Task: [C-project-with-Unreal-Engine-5.x-on-PC.-game/jwxokj1djk0i](https://cosine.sh/58oybfguweeq/C-project-with-Unreal-Engine-5.x-on-PC.-game/task/jwxokj1djk0i)
Author: lm600k
